### PR TITLE
Remove google+ sharing

### DIFF
--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -37,9 +37,6 @@
             <a class="facebook" href="https://www.facebook.com/sharer/sharer.php?u={{ .Permalink }}" onclick="window.open(this.href, 'facebook-share','width=580,height=296');return false;">
               <i class="ic ic-facebook"></i><span class="hidden">Facebook</span>
             </a>
-            <a class="googleplus" href="https://plus.google.com/share?url={{ .Permalink }}" onclick="window.open(this.href, 'google-plus-share', 'width=490,height=530');return false;">
-              <i class="ic ic-googleplus"></i><span class="hidden">Google+</span>
-            </a>
             <div class="clear"></div>
         </div>
 


### PR DESCRIPTION
G+ is no longer supported by Google and was shut down.